### PR TITLE
Update syntax highlighting grammars to include new keywords

### DIFF
--- a/Editors/VS Code/syntaxes/stacko.tmLanguage.json
+++ b/Editors/VS Code/syntaxes/stacko.tmLanguage.json
@@ -40,7 +40,7 @@
 				},
 				{
 					"name": "keyword.other.stacko",
-					"match": "\\b(dup|pop|not|printLine|readLine|exit|assert|assertEqual|assertNotEqual|toNum|toString|toBool)\\b"
+					"match": "\\b(dup|pop|not|printLine|readLine|exit|assert|assertEqual|assertNotEqual|toNum|toString|toBool|waitMore|random|getElement)\\b"
 				}
 			]
 		},

--- a/Editors/Vim/stacko.vim
+++ b/Editors/Vim/stacko.vim
@@ -18,7 +18,7 @@ endif
 syn keyword stackoConditional if else
 syn keyword stackoRepeat while
 syn keyword stackoOperator + - * / % = < <= > >=
-syn keyword stackoKeyword dup pop not print printLine readLine exit assert assertEqual assertNotEqual toNum toString toBool fnn const file var set
+syn keyword stackoKeyword dup pop not print printLine readLine exit assert assertEqual assertNotEqual toNum toString toBool fnn const file var set waitMore random getElement
 
 syn region stackoString start='"' end='"'
 syn match stackoFloat "\d+(\.\d+)?"


### PR DESCRIPTION
Updated the Vim and VS Code highlighting grammars to highlight the `waitMore`, `random`, and `getElement` keywords.